### PR TITLE
Special improvements added.

### DIFF
--- a/BreadcrumbsUtility.php
+++ b/BreadcrumbsUtility.php
@@ -26,7 +26,8 @@ class BreadcrumbsUtility
 
         foreach ($links as $key => &$link) {
             if(is_array($link)) {
-                $link['template'] = self::getTemplate($link['label'], $link['url'], $key+$home);
+                $url = (isset($link['url'])) ? $link['url'] : false;
+                $link['template'] = self::getTemplate($link['label'], $url, $key+$home);
             }
         }
 
@@ -55,14 +56,20 @@ class BreadcrumbsUtility
      * It used only within the class, and contains markup template schema.org/BreadcrumbList
      *
      * @param string $label
-     * @param array|string $url
+     * @param array|string|bool $url if the $url is false, it is the current page.
      * @param int $key
      * @return string template microdata
      */
     private static function getTemplate($label, $url, $key)
     {
-        return '<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">'
-                . Html::a('<span itemprop="name">'.$label.'</span>', Url::to($url), ['itemprop'=>'item'])
+        $template = '<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">'
+            . Html::a('<span itemprop="name">'.$label.'</span>', Url::to($url), ['itemprop'=>'item'])
+            . '<meta itemprop="position" content="'.$key.'" /></li>';
+        if ($url === false)
+            $template = '<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="text-light" style="opacity: 0.65;">'
+                . Html::tag('span', $label, ['itemprop'=>'name'])
                 . '<meta itemprop="position" content="'.$key.'" /></li>';
+
+        return $template;
     }
 }

--- a/README.md
+++ b/README.md
@@ -54,4 +54,39 @@ Breadcrumbs::widget([
 ]);
 ```
 
+For view pages:
+```php
+// after set $this->title
+$this->params['breadcrumbs'][] = [
+    'label' => 'Articles',
+    'url' => Url::toRoute('press-center/articles'),
+];
+$this->params['breadcrumbs'][] = [
+    'label' => $this->title,
+    // if there is no url element, then this is the current page.
+];
+```
+
+HTML result:
+```html
+<ul itemscope="" itemtype="http://schema.org/BreadcrumbList">
+    <li itemprop="itemListElement" itemscope="" itemtype="http://schema.org/ListItem">
+        <a href="/" itemprop="item">
+            <span itemprop="name">Home page</span>
+        </a>
+        <meta itemprop="position" content="1">
+    </li>
+    <li itemprop="itemListElement" itemscope="" itemtype="http://schema.org/ListItem">
+        <a href="/press-center/articles" itemprop="item">
+            <span itemprop="name">Articles</span>
+        </a>
+        <meta itemprop="position" content="2">
+    </li>
+    <li itemprop="itemListElement" itemscope="" itemtype="http://schema.org/ListItem" class="text-light" style="opacity: 0.65;">
+        <span itemprop="name">10 Must-Read Books for Programmers</span>
+        <meta itemprop="position" content="3">
+    </li>
+</ul>
+```
+
 That's all. Check it.


### PR DESCRIPTION
If "view" does not send the "url" item for the breadcrumbs array from the pages, it will return an "Undefined index: url" error. I fixed the widget functionality to fix this problem. It no longer gives an error if it does not send the "url" element or sends it false. Now if the "url" element is not sent, then it is the current page and does not add the "a" tag.

I also added examples to the README.md file on how to use it in the "view" pages, and how it looks in HTML.